### PR TITLE
fix(mapping): properly handle nil index paths

### DIFF
--- a/Example/Tests/HRSIndexPathMapperTests.m
+++ b/Example/Tests/HRSIndexPathMapperTests.m
@@ -130,4 +130,12 @@
 	expect([foundIndexPath indexAtPosition:1]).to.equal(0);
 }
 
+- (void)testMappingNilIndexPath {
+	NSIndexPath *nilIndexPath = [self.sut dynamicIndexPathForStaticIndexPath:nil];
+	expect(nilIndexPath).to.beNil();
+	
+	nilIndexPath = [self.sut staticIndexPathForDynamicIndexPath:nil];
+	expect(nilIndexPath).to.beNil();
+}
+
 @end

--- a/Pod/Classes/HRSIndexPathMapping/HRSIndexPathMapper.m
+++ b/Pod/Classes/HRSIndexPathMapping/HRSIndexPathMapper.m
@@ -77,6 +77,10 @@
 #pragma mark - mapping
 
 - (NSIndexPath *)dynamicIndexPathForStaticIndexPath:(NSIndexPath *)indexPath {
+	if (indexPath == nil) {
+		return nil;
+	}
+	
 	NSUInteger indexes[indexPath.length];
 	[indexPath getIndexes:indexes];
 	
@@ -87,6 +91,10 @@
 }
 
 - (NSIndexPath *)staticIndexPathForDynamicIndexPath:(NSIndexPath *)indexPath {
+	if (indexPath == nil) {
+		return nil;
+	}
+	
 	NSUInteger indexes[indexPath.length];
 	[indexPath getIndexes:indexes];
 	


### PR DESCRIPTION
ensure that the index path mapper returns a nil index path if a nil index path is passed to one of the mapping methods `-dynamicIndexPathForStaticIndexPath:` or `-staticIndexPathForDynamicIndexPath:`
