### PR TITLE
fix(section controller): ensure that there are no retain cycles in the case a section controller retains its table view

### DIFF
--- a/Pod/Classes/HRSSectionController/HRSTableViewSectionCoordinator.m
+++ b/Pod/Classes/HRSSectionController/HRSTableViewSectionCoordinator.m
@@ -115,6 +115,10 @@ static void *const CoordinatorTableViewLink = (void *)&CoordinatorTableViewLink;
 }
 
 - (void)dealloc {
+	// notify the section controller that the new table is now nil, in case they
+	// cached it.
+	self.sectionController = nil;
+	
 	// remove association if present
 	UITableView *tableView = self.tableView;
 	if (tableView) {


### PR DESCRIPTION
This ensures that every section controller gets an update to `tableViewDidChange:` with a `nil` table view to remove a cached table view. This prevents retain cycles between the table view and the section controller that might occur because the table view actually is a proxy that needs to retain its table view and its section controller.
