### PR TITLE
Fixes MIP-2062: Crash on iPad

### DIFF
--- a/Pod/Classes/HRSSectionController/HRSTableViewSectionCoordinator.m
+++ b/Pod/Classes/HRSSectionController/HRSTableViewSectionCoordinator.m
@@ -122,6 +122,8 @@ static void *const CoordinatorTableViewLink = (void *)&CoordinatorTableViewLink;
 	// remove association if present
 	UITableView *tableView = self.tableView;
 	if (tableView) {
+        tableView.dataSource = nil;
+        tableView.delegate = nil;
 		objc_setAssociatedObject(tableView, CoordinatorTableViewLink, nil, OBJC_ASSOCIATION_ASSIGN);
 	}
 }


### PR DESCRIPTION
In case the delegate was deallocated while the scroll view was still
scrolling, the app crashed (delegate & data source are unsafe_unretained)
when the scroll view tried to send messages. This was fixed.