### PR TITLE
Feature/#16 crash when resetting sections

### DIFF
--- a/Example/HRSAdvancedTableViews.xcodeproj/project.pbxproj
+++ b/Example/HRSAdvancedTableViews.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		79249A1D19EEA37700F6A95C /* HRSSimpleIndexPathMappingTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 79249A1C19EEA37700F6A95C /* HRSSimpleIndexPathMappingTableViewController.m */; };
 		79311C4319E820D100FC9751 /* HRSIndexPathMapperTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 79311C4219E820D100FC9751 /* HRSIndexPathMapperTableViewTests.m */; };
 		7933E6C31B01FA3000437C84 /* HRSTableViewSectionControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7933E6C21B01FA3000437C84 /* HRSTableViewSectionControllerTests.m */; };
+		7933E6C61B02470F00437C84 /* HRSSectionControllerDynamicDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7933E6C51B02470F00437C84 /* HRSSectionControllerDynamicDemoViewController.m */; };
 		797B586519EFC15500F09EA7 /* HRSTreeIndexPathMappingTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 797B586419EFC15500F09EA7 /* HRSTreeIndexPathMappingTableViewController.m */; };
 		799D7C4F19DD723600D455C8 /* HRSTableViewSectionCoordinatorTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 799D7C4E19DD723600D455C8 /* HRSTableViewSectionCoordinatorTableViewTests.m */; };
 		79D8EA6819E2BBE800F56065 /* HRSSectionControllerDemoSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 79D8EA6719E2BBE800F56065 /* HRSSectionControllerDemoSectionController.m */; };
@@ -73,6 +74,8 @@
 		79249A1C19EEA37700F6A95C /* HRSSimpleIndexPathMappingTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSSimpleIndexPathMappingTableViewController.m; sourceTree = "<group>"; };
 		79311C4219E820D100FC9751 /* HRSIndexPathMapperTableViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSIndexPathMapperTableViewTests.m; sourceTree = "<group>"; };
 		7933E6C21B01FA3000437C84 /* HRSTableViewSectionControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSTableViewSectionControllerTests.m; sourceTree = "<group>"; };
+		7933E6C41B02470F00437C84 /* HRSSectionControllerDynamicDemoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HRSSectionControllerDynamicDemoViewController.h; sourceTree = "<group>"; };
+		7933E6C51B02470F00437C84 /* HRSSectionControllerDynamicDemoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSSectionControllerDynamicDemoViewController.m; sourceTree = "<group>"; };
 		797B586319EFC15500F09EA7 /* HRSTreeIndexPathMappingTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HRSTreeIndexPathMappingTableViewController.h; sourceTree = "<group>"; };
 		797B586419EFC15500F09EA7 /* HRSTreeIndexPathMappingTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSTreeIndexPathMappingTableViewController.m; sourceTree = "<group>"; };
 		799D7C4E19DD723600D455C8 /* HRSTableViewSectionCoordinatorTableViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSTableViewSectionCoordinatorTableViewTests.m; sourceTree = "<group>"; };
@@ -152,6 +155,8 @@
 				79249A1719EE9F3600F6A95C /* HRSDemoListTableViewController.m */,
 				6003F5A5195388D20070C39A /* HRSSectionControllerDemoViewController.h */,
 				6003F5A6195388D20070C39A /* HRSSectionControllerDemoViewController.m */,
+				7933E6C41B02470F00437C84 /* HRSSectionControllerDynamicDemoViewController.h */,
+				7933E6C51B02470F00437C84 /* HRSSectionControllerDynamicDemoViewController.m */,
 				79D8EA6619E2BBE800F56065 /* HRSSectionControllerDemoSectionController.h */,
 				79D8EA6719E2BBE800F56065 /* HRSSectionControllerDemoSectionController.m */,
 				79249A1B19EEA37700F6A95C /* HRSSimpleIndexPathMappingTableViewController.h */,
@@ -382,6 +387,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				79D8EA6819E2BBE800F56065 /* HRSSectionControllerDemoSectionController.m in Sources */,
+				7933E6C61B02470F00437C84 /* HRSSectionControllerDynamicDemoViewController.m in Sources */,
 				79249A1D19EEA37700F6A95C /* HRSSimpleIndexPathMappingTableViewController.m in Sources */,
 				6003F5A7195388D20070C39A /* HRSSectionControllerDemoViewController.m in Sources */,
 				797B586519EFC15500F09EA7 /* HRSTreeIndexPathMappingTableViewController.m in Sources */,

--- a/Example/HRSAdvancedTableViews.xcodeproj/project.pbxproj
+++ b/Example/HRSAdvancedTableViews.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		79249A1A19EEA21F00F6A95C /* Launch Screen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 79249A1919EEA21F00F6A95C /* Launch Screen.xib */; };
 		79249A1D19EEA37700F6A95C /* HRSSimpleIndexPathMappingTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 79249A1C19EEA37700F6A95C /* HRSSimpleIndexPathMappingTableViewController.m */; };
 		79311C4319E820D100FC9751 /* HRSIndexPathMapperTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 79311C4219E820D100FC9751 /* HRSIndexPathMapperTableViewTests.m */; };
+		7933E6C31B01FA3000437C84 /* HRSTableViewSectionControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7933E6C21B01FA3000437C84 /* HRSTableViewSectionControllerTests.m */; };
 		797B586519EFC15500F09EA7 /* HRSTreeIndexPathMappingTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 797B586419EFC15500F09EA7 /* HRSTreeIndexPathMappingTableViewController.m */; };
 		799D7C4F19DD723600D455C8 /* HRSTableViewSectionCoordinatorTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 799D7C4E19DD723600D455C8 /* HRSTableViewSectionCoordinatorTableViewTests.m */; };
 		79D8EA6819E2BBE800F56065 /* HRSSectionControllerDemoSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 79D8EA6719E2BBE800F56065 /* HRSSectionControllerDemoSectionController.m */; };
@@ -71,6 +72,7 @@
 		79249A1B19EEA37700F6A95C /* HRSSimpleIndexPathMappingTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HRSSimpleIndexPathMappingTableViewController.h; sourceTree = "<group>"; };
 		79249A1C19EEA37700F6A95C /* HRSSimpleIndexPathMappingTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSSimpleIndexPathMappingTableViewController.m; sourceTree = "<group>"; };
 		79311C4219E820D100FC9751 /* HRSIndexPathMapperTableViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSIndexPathMapperTableViewTests.m; sourceTree = "<group>"; };
+		7933E6C21B01FA3000437C84 /* HRSTableViewSectionControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSTableViewSectionControllerTests.m; sourceTree = "<group>"; };
 		797B586319EFC15500F09EA7 /* HRSTreeIndexPathMappingTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HRSTreeIndexPathMappingTableViewController.h; sourceTree = "<group>"; };
 		797B586419EFC15500F09EA7 /* HRSTreeIndexPathMappingTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSTreeIndexPathMappingTableViewController.m; sourceTree = "<group>"; };
 		799D7C4E19DD723600D455C8 /* HRSTableViewSectionCoordinatorTableViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HRSTableViewSectionCoordinatorTableViewTests.m; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 			children = (
 				79DD808A19DD56E50095107F /* HRSTableViewSectionCoordinatorTests.m */,
 				799D7C4E19DD723600D455C8 /* HRSTableViewSectionCoordinatorTableViewTests.m */,
+				7933E6C21B01FA3000437C84 /* HRSTableViewSectionControllerTests.m */,
 				791F2AE519E8013D00221D78 /* HRSIndexPathMapperTests.m */,
 				79311C4219E820D100FC9751 /* HRSIndexPathMapperTableViewTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
@@ -392,6 +395,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7933E6C31B01FA3000437C84 /* HRSTableViewSectionControllerTests.m in Sources */,
 				799D7C4F19DD723600D455C8 /* HRSTableViewSectionCoordinatorTableViewTests.m in Sources */,
 				79DD808B19DD56E50095107F /* HRSTableViewSectionCoordinatorTests.m in Sources */,
 				79311C4319E820D100FC9751 /* HRSIndexPathMapperTableViewTests.m in Sources */,

--- a/Example/HRSAdvancedTableViews/HRSDemoListTableViewController.m
+++ b/Example/HRSAdvancedTableViews/HRSDemoListTableViewController.m
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSUInteger, Demo) {
 						 // Section Controller
 						 @[
 							 @"HRSSectionControllerDemoViewController",
+                             @"HRSSectionControllerDynamicDemoViewController",
 							 ],
 						 
 						 // Index Path Mapping

--- a/Example/HRSAdvancedTableViews/HRSSectionControllerDemoSectionController.m
+++ b/Example/HRSAdvancedTableViews/HRSSectionControllerDemoSectionController.m
@@ -47,4 +47,8 @@
 	}
 }
 
+- (void)tableView:(UITableView *)tableView didEndDisplayingCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSLog(@"did end displaying %@", indexPath);
+}
+
 @end

--- a/Example/HRSAdvancedTableViews/HRSSectionControllerDynamicDemoViewController.h
+++ b/Example/HRSAdvancedTableViews/HRSSectionControllerDynamicDemoViewController.h
@@ -1,0 +1,19 @@
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface HRSSectionControllerDynamicDemoViewController : UITableViewController
+
+@end

--- a/Example/HRSAdvancedTableViews/HRSSectionControllerDynamicDemoViewController.m
+++ b/Example/HRSAdvancedTableViews/HRSSectionControllerDynamicDemoViewController.m
@@ -1,0 +1,100 @@
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+//
+
+#import "HRSSectionControllerDynamicDemoViewController.h"
+
+#import <HRSAdvancedTableViews/HRSSectionController.h>
+#import "HRSSectionControllerDemoSectionController.h"
+
+
+@interface HRSSectionControllerDynamicDemoViewController ()
+
+@property (nonatomic, strong, readonly) HRSTableViewSectionController *controllerOne;
+@property (nonatomic, strong, readonly) HRSTableViewSectionController *controllerTwo;
+@property (nonatomic, strong, readonly) HRSTableViewSectionController *controllerThree;
+
+@property (nonatomic, weak, readonly) UISwitch *switchOne;
+@property (nonatomic, weak, readonly) UISwitch *switchTwo;
+@property (nonatomic, weak, readonly) UISwitch *switchThree;
+
+@property (nonatomic, strong, readonly) HRSTableViewSectionCoordinator *coordinator;
+
+@end
+
+
+@implementation HRSSectionControllerDynamicDemoViewController
+
+- (instancetype)init {
+	self = [super init];
+	if (self) {
+		self.title = @"Section Controller";
+		
+        HRSTableViewSectionController *controllerOne = [HRSSectionControllerDemoSectionController new];
+        _controllerOne = controllerOne;
+        
+        HRSTableViewSectionController *controllerTwo = [HRSSectionControllerDemoSectionController new];
+        _controllerTwo = controllerTwo;
+        
+        HRSTableViewSectionController *controllerThree = [HRSSectionControllerDemoSectionController new];
+        _controllerThree = controllerThree;
+        
+		HRSTableViewSectionCoordinator *coordinator = [HRSTableViewSectionCoordinator new];
+        [coordinator setSectionController:@[ controllerOne, controllerTwo, controllerThree ]];
+		_coordinator = coordinator;
+        
+        UISwitch *switchOne = [UISwitch new];
+        switchOne.on = YES;
+        [switchOne addTarget:self action:@selector(visibilityStateChanged:) forControlEvents:UIControlEventValueChanged];
+        _switchOne = switchOne;
+        
+        UISwitch *switchTwo = [UISwitch new];
+        switchTwo.on = YES;
+        [switchTwo addTarget:self action:@selector(visibilityStateChanged:) forControlEvents:UIControlEventValueChanged];
+        _switchTwo = switchTwo;
+        
+        UISwitch *switchThree = [UISwitch new];
+        switchThree.on = YES;
+        [switchThree addTarget:self action:@selector(visibilityStateChanged:) forControlEvents:UIControlEventValueChanged];
+        _switchThree = switchThree;
+        
+        self.navigationItem.rightBarButtonItems = @[
+                                                    [[UIBarButtonItem alloc] initWithCustomView:switchOne],
+                                                    [[UIBarButtonItem alloc] initWithCustomView:switchTwo],
+                                                    [[UIBarButtonItem alloc] initWithCustomView:switchThree]
+                                                    ];
+	}
+	return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+	
+	[self.coordinator setTableView:[self tableView]];
+}
+
+- (IBAction)visibilityStateChanged:(id)sender {
+    NSMutableArray *controller = [NSMutableArray new];
+    if (self.switchOne.isOn) {
+        [controller addObject:self.controllerOne];
+    }
+    if (self.switchTwo.isOn) {
+        [controller addObject:self.controllerTwo];
+    }
+    if (self.switchThree.isOn) {
+        [controller addObject:self.controllerThree];
+    }
+    [self.coordinator setSectionController:controller animated:YES];
+}
+
+@end

--- a/Example/Tests/HRSTableViewSectionControllerTests.m
+++ b/Example/Tests/HRSTableViewSectionControllerTests.m
@@ -1,0 +1,109 @@
+//
+//  HRSTableViewSectionControllerTests.m
+//  HRSAdvancedTableViews
+//
+//  Created by Michael Ochs on 12/05/15.
+//  Copyright (c) 2015 Michael Ochs. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+
+#import <HRSAdvancedTableViews/HRSSectionController.h>
+
+
+@interface HRSTableViewSectionControllerRemovalTest : HRSTableViewSectionController
+@property (nonatomic, assign, readwrite) NSInteger didEndDisplayingCellHitCount;
+@end
+
+@implementation HRSTableViewSectionControllerRemovalTest
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return 2;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    return [UITableViewCell new];
+}
+
+- (void)tableView:(UITableView *)tableView didEndDisplayingCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    self.didEndDisplayingCellHitCount++;
+}
+
+- (void)resetHitCount {
+    self.didEndDisplayingCellHitCount = 0;
+}
+
+@end
+
+
+@interface HRSTableViewSectionControllerTests : XCTestCase
+
+@property (nonatomic, strong, readwrite) UITableView *tableView;
+@property (nonatomic, strong, readwrite) HRSTableViewSectionCoordinator *sut;
+
+@end
+
+
+@implementation HRSTableViewSectionControllerTests
+
+- (void)setUp {
+    [super setUp];
+    
+    UITableView *tableView = [[UITableView alloc] initWithFrame:CGRectMake(0.0, 0.0, 320.0, 480.0) style:UITableViewStylePlain];
+    
+    HRSTableViewSectionCoordinator *sut = [HRSTableViewSectionCoordinator new];
+    [sut setTableView:tableView];
+    self.sut = sut;
+    
+    self.tableView = tableView;
+}
+
+- (void)tearDown {
+    self.tableView = nil;
+    self.sut = nil;
+    
+    [super tearDown];
+}
+
+/**
+ This tests the issue #16, which leads to a crash as the table view sends 
+ didEndDisplayingCell:forRowAtIndexPath: to a section controller that is not
+ in the list of section controllers anymore.
+ @see https://github.com/Hotel-Reservation-Service/HRSAdvancedTableViews/issues/16
+ */
+- (void)testDidEndDisplayingNotCrashing {
+    HRSTableViewSectionControllerRemovalTest *controllerOne = [HRSTableViewSectionControllerRemovalTest new];
+    HRSTableViewSectionControllerRemovalTest *controllerTwo = [HRSTableViewSectionControllerRemovalTest new];
+    self.sut.sectionController = @[ controllerOne, controllerTwo ];
+    [self.tableView reloadData];
+    [self.tableView layoutIfNeeded];
+    
+    self.sut.sectionController = @[ controllerOne ];
+    [self.tableView reloadData];
+}
+
+- (void)testDidEndDisplayingCallingTheRightSectionController {
+    HRSTableViewSectionControllerRemovalTest *controllerOne = [HRSTableViewSectionControllerRemovalTest new];
+    HRSTableViewSectionControllerRemovalTest *controllerTwo = [HRSTableViewSectionControllerRemovalTest new];
+    self.sut.sectionController = @[ controllerOne, controllerTwo ];
+    [self.tableView layoutIfNeeded];
+    
+    [controllerOne resetHitCount];
+    [controllerTwo resetHitCount];
+    self.sut.sectionController = @[ controllerOne ];
+    [self.tableView layoutIfNeeded];
+    expect(controllerTwo.didEndDisplayingCellHitCount).to.beGreaterThan(0);
+
+    self.sut.sectionController = @[ controllerOne, controllerTwo ];
+    [self.tableView layoutIfNeeded];
+    
+    [controllerOne resetHitCount];
+    [controllerTwo resetHitCount];
+    self.sut.sectionController = @[ controllerTwo ];
+    [self.tableView layoutIfNeeded];
+    expect(controllerOne.didEndDisplayingCellHitCount).to.beGreaterThan(0);
+}
+
+@end

--- a/Example/Tests/HRSTableViewSectionCoordinatorTableViewTests.m
+++ b/Example/Tests/HRSTableViewSectionCoordinatorTableViewTests.m
@@ -22,7 +22,7 @@
 @interface HRSTableViewSectionCoordinator (Tests)
 
 - (UITableView *)tableView;
-- (id<HRSTableViewSectionController>)_sectionControllerForTableSection:(NSInteger)section;
+- (id<HRSTableViewSectionController>)_sectionControllerForTableSection:(NSInteger)section beforeTransition:(BOOL)beforeTransition;
 
 @end
 
@@ -72,7 +72,7 @@
 	[self.sut setSectionController:sectionController animated:NO];
 	
 	NSIndexPath *tableViewIndexPath = [NSIndexPath indexPathForRow:4 inSection:1];
-	id<HRSTableViewSectionController> controller = [self.sut _sectionControllerForTableSection:tableViewIndexPath.section];
+	id<HRSTableViewSectionController> controller = [self.sut _sectionControllerForTableSection:tableViewIndexPath.section beforeTransition:NO];
 	expect(controller).to.beIdenticalTo([sectionController lastObject]);
 }
 

--- a/Pod/Classes/HRSSectionController/HRSTableViewSectionCoordinator.m
+++ b/Pod/Classes/HRSSectionController/HRSTableViewSectionCoordinator.m
@@ -192,12 +192,21 @@ static void *const CoordinatorTableViewLink = (void *)&CoordinatorTableViewLink;
 #pragma mark - proxying
 
 - (UITableView *)tableViewForSectionController:(id<HRSTableViewSectionController>)controller {
+    if (controller == nil || self.tableView == nil) {
+        return nil;
+    }
 	_HRSTableViewSectionCoordinatorProxy *proxy = [_HRSTableViewSectionCoordinatorProxy proxyWithController:controller tableView:self.tableView];
 	return (UITableView *)proxy;
 }
 
 - (id<HRSTableViewSectionController>)sectionControllerForTableSection:(NSInteger)section {
+    if (self.tableView == nil) {
+        return nil;
+    }
 	id<HRSTableViewSectionController> controller = [self _sectionControllerForTableSection:section];
+    if (controller == nil) {
+        return nil;
+    }
 	_HRSTableViewSectionCoordinatorProxy *proxy = [_HRSTableViewSectionCoordinatorProxy reverseProxyWithController:controller tableView:self.tableView];
 	return (id<HRSTableViewSectionController>)proxy;
 }
@@ -254,7 +263,11 @@ static void *const CoordinatorTableViewLink = (void *)&CoordinatorTableViewLink;
 }
 
 - (id<HRSTableViewSectionController>)_sectionControllerForTableSection:(NSInteger)section {
-	return [self.sectionController objectAtIndex:section];
+    if (self.sectionController.count > section) {
+        return [self.sectionController objectAtIndex:section];
+    } else {
+        return nil;
+    }
 }
 
 - (void)_tableViewDidChange {

--- a/Pod/Classes/HRSSectionController/HRSTableViewSectionCoordinator.m
+++ b/Pod/Classes/HRSSectionController/HRSTableViewSectionCoordinator.m
@@ -29,6 +29,8 @@
 @property (nonatomic, weak, readwrite) UITableView *tableView;
 @property (nonatomic, strong, readwrite) HRSTableViewSectionTransformer *transformer;
 
+@property (nonatomic, strong, readwrite) NSArray *oldSectionController; /// This is the list of old section controllers during a transition.
+
 @end
 
 
@@ -85,6 +87,8 @@ static void *const CoordinatorTableViewLink = (void *)&CoordinatorTableViewLink;
 	// store a mutable array.
 	NSArray *oldSectionController = _sectionController;
 	NSArray *newSectionController = [sectionController copy];
+    
+    self.oldSectionController = oldSectionController;
 	
 	// build sets for upcoming operations
 	NSSet *oldSectionControllerSet = [NSSet setWithArray:oldSectionController];
@@ -121,15 +125,34 @@ static void *const CoordinatorTableViewLink = (void *)&CoordinatorTableViewLink;
 	}
 	
 	if (animated) {
+        // use a transaction to be able to hook to the end of the table view
+        // animation. UITableView uses core animation, so this works reliably.
+        [CATransaction begin];
+        [CATransaction setCompletionBlock:^{
+            // this completion handler fires before the core animation callbacks,
+            // which will trigger the table view did end displaying callbacks,
+            // so we need to delay this ones more!
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self configureTransformer]; // delay this until here ensure a smooth transition
+                self.oldSectionController = nil;
+            });
+        }];
+        
 		[self.tableView beginUpdates];
 		_sectionController = newSectionController;
-        [self configureTransformer];
+        // if we are animating, we hold back the new transformer to guarantee a smooth animation
 		[self _animateFromSections:oldSectionController toSections:newSectionController];
 		[self.tableView endUpdates];
+        
+        [CATransaction commit];
+        
 	} else {
 		_sectionController = newSectionController;
         [self configureTransformer];
 		[self.tableView reloadData];
+        dispatch_async(dispatch_get_main_queue(), ^{ // wait for the table view to relayout
+            self.oldSectionController = nil;
+        });
 	}
 }
 
@@ -200,14 +223,21 @@ static void *const CoordinatorTableViewLink = (void *)&CoordinatorTableViewLink;
 }
 
 - (id<HRSTableViewSectionController>)sectionControllerForTableSection:(NSInteger)section {
+    return [self sectionControllerForTableSection:section beforeTransition:NO];
+}
+
+- (id<HRSTableViewSectionController>)sectionControllerForTableSection:(NSInteger)section beforeTransition:(BOOL)beforeTransition {
     if (self.tableView == nil) {
         return nil;
     }
-	id<HRSTableViewSectionController> controller = [self _sectionControllerForTableSection:section];
+	id<HRSTableViewSectionController> controller = [self _sectionControllerForTableSection:section beforeTransition:beforeTransition];
     if (controller == nil) {
         return nil;
     }
 	_HRSTableViewSectionCoordinatorProxy *proxy = [_HRSTableViewSectionCoordinatorProxy reverseProxyWithController:controller tableView:self.tableView];
+    if (beforeTransition && self.oldSectionController) {
+        proxy.sectionControllers = self.oldSectionController;
+    }
 	return (id<HRSTableViewSectionController>)proxy;
 }
 
@@ -262,9 +292,10 @@ static void *const CoordinatorTableViewLink = (void *)&CoordinatorTableViewLink;
 	[tableView reloadData];
 }
 
-- (id<HRSTableViewSectionController>)_sectionControllerForTableSection:(NSInteger)section {
-    if (self.sectionController.count > section) {
-        return [self.sectionController objectAtIndex:section];
+- (id<HRSTableViewSectionController>)_sectionControllerForTableSection:(NSInteger)section beforeTransition:(BOOL)beforeTransition {
+    NSArray *sectionController = (beforeTransition && self.oldSectionController ? self.oldSectionController : self.sectionController);
+    if (sectionController.count > section) {
+        return [sectionController objectAtIndex:section];
     } else {
         return nil;
     }
@@ -389,21 +420,21 @@ static void *const CoordinatorTableViewLink = (void *)&CoordinatorTableViewLink;
 }
 
 - (void)tableView:(UITableView *)tableView didEndDisplayingCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
-	id<HRSTableViewSectionController> sectionController = [self sectionControllerForTableSection:indexPath.section];
+	id<HRSTableViewSectionController> sectionController = [self sectionControllerForTableSection:indexPath.section beforeTransition:YES];
 	if ([sectionController respondsToSelector:_cmd]) {
 		[sectionController tableView:tableView didEndDisplayingCell:cell forRowAtIndexPath:indexPath];
 	}
 }
 
 - (void)tableView:(UITableView *)tableView didEndDisplayingHeaderView:(UIView *)view forSection:(NSInteger)section {
-	id<HRSTableViewSectionController> sectionController = [self sectionControllerForTableSection:section];
+	id<HRSTableViewSectionController> sectionController = [self sectionControllerForTableSection:section beforeTransition:YES];
 	if ([sectionController respondsToSelector:_cmd]) {
 		[sectionController tableView:tableView didEndDisplayingHeaderView:view forSection:section];
 	}
 }
 
 - (void)tableView:(UITableView *)tableView didEndDisplayingFooterView:(UIView *)view forSection:(NSInteger)section {
-	id<HRSTableViewSectionController> sectionController = [self sectionControllerForTableSection:section];
+	id<HRSTableViewSectionController> sectionController = [self sectionControllerForTableSection:section beforeTransition:YES];
 	if ([sectionController respondsToSelector:_cmd]) {
 		[sectionController tableView:tableView didEndDisplayingFooterView:view forSection:section];
 	}

--- a/Pod/Classes/HRSSectionController/Private/_HRSTableViewSectionCoordinatorProxy.h
+++ b/Pod/Classes/HRSSectionController/Private/_HRSTableViewSectionCoordinatorProxy.h
@@ -46,6 +46,20 @@
 @interface _HRSTableViewSectionCoordinatorProxy : NSProxy
 
 /**
+ This is the list of all section controllers that are currently displayed in the
+ table view.
+ 
+ The proxy uses this information to calculate the mapping of index pathes and
+ sections. The section controller associated to the proxy must be one element
+ of this array; otherwise, setting this array will raise an exception.
+ 
+ @note if you do not set this value, the proxy tries to determine the list of
+       available section controllers itself. This might not always be correct.
+       (see issue #16)
+ */
+@property (nonatomic, strong, readwrite) NSArray *sectionControllers;
+
+/**
  Register a new selector that participates in object mapping.
  
  The newly registered selector will immediately be taken into account by all

--- a/Pod/Classes/HRSSectionController/Private/_HRSTableViewSectionCoordinatorProxy.m
+++ b/Pod/Classes/HRSSectionController/Private/_HRSTableViewSectionCoordinatorProxy.m
@@ -72,6 +72,14 @@ static NSMutableDictionary *transformer;
 	return self;
 }
 
+- (NSArray *)sectionControllers {
+    if (_sectionControllers) {
+        return _sectionControllers;
+    }
+    
+    return self.controller.coordinator.sectionController;
+}
+
 
 
 #pragma mark - forwarding
@@ -100,12 +108,16 @@ static NSMutableDictionary *transformer;
 	BOOL reverseLogic = reverse ^ self.reverseProxying;
 	
 	if ([object isKindOfClass:[NSIndexPath class]]) {
+        NSIndexPath *indexPath = object;
 		NSIndexPath *mappedIndexPath;
 		if (reverseLogic) {
-			mappedIndexPath = [self.controller.coordinator controllerIndexPathForTableViewIndexPath:object withController:self.controller];
+            mappedIndexPath = [NSIndexPath indexPathForRow:indexPath.row inSection:0];
 			
 		} else {
-			mappedIndexPath = [self.controller.coordinator tableViewIndexPathForControllerIndexPath:object withController:self.controller];
+            NSInteger section = [self.sectionControllers indexOfObject:self.controller];
+            if (section != NSNotFound) {
+                mappedIndexPath = [NSIndexPath indexPathForRow:indexPath.row inSection:section];
+            }
 		}
 		return mappedIndexPath;
 		


### PR DESCRIPTION
This PR fixes #16 

While the section coordinator is in the process of resetting the section controllers, it now maintains a list of old section controllers and dispatches methods like `tableView:didEndDisplayingCell:forRowAtIndexPath:` to the old section controller list while being in a transition state.

Furthermore this PR also tries to prevent crashes when accessing a section that does not have a section controller anymore by simply returning `nil` as the controller instead of trying to access the section controller array at an invalid index.