### PR TITLE
Override designated initializer of base class.

### DIFF
--- a/Pod/Classes/HRSIndexPathMapping/Private/HRSIndexPathMapperNode.m
+++ b/Pod/Classes/HRSIndexPathMapping/Private/HRSIndexPathMapperNode.m
@@ -28,6 +28,11 @@
 
 @implementation HRSIndexPathMapperNode
 
+- (instancetype)init {
+    NSAssert(NO, @"You should always provide an index explicitly, so better use -initWithIndex:");
+    return [self initWithIndex:0];
+}
+
 - (instancetype)initWithIndex:(NSUInteger)index {
 	self = [super init];
 	if (self) {


### PR DESCRIPTION
Xcode 7 is somewhat more fussy about not overriding the base classes' designated initializers.
Well. So be it then.
