### PR TITLE
Bugfix/scroll view did scroll called without check

### DIFF
--- a/Example/HRSAdvancedTableViews.xcodeproj/project.pbxproj
+++ b/Example/HRSAdvancedTableViews.xcodeproj/project.pbxproj
@@ -234,8 +234,6 @@
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				D2CABDDBB74E41D2A7B5C949 /* [CP] Copy Pods Resources */,
-				3C15785D670EF1EBCEDE98AB /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -254,8 +252,6 @@
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
-				EEF8D449ACB0480FAA21F197 /* [CP] Copy Pods Resources */,
-				F4944FECF41F8CA38DD10107 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -321,34 +317,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3C15785D670EF1EBCEDE98AB /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-HRSAdvancedTableViews/Pods-HRSAdvancedTableViews-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		9FD9C2C5077148F59AA1D219 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HRSAdvancedTableViews-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		C26BA02FAC094BA19B10E2F9 /* [CP] Check Pods Manifest.lock */ = {
@@ -357,58 +341,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Tests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		D2CABDDBB74E41D2A7B5C949 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-HRSAdvancedTableViews/Pods-HRSAdvancedTableViews-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		EEF8D449ACB0480FAA21F197 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F4944FECF41F8CA38DD10107 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/HRSAdvancedTableViews.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/HRSAdvancedTableViews.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,15 +12,20 @@ DEPENDENCIES:
   - HRSAdvancedTableViews (from `../`)
   - OCMock
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Expecta
+    - OCMock
+
 EXTERNAL SOURCES:
   HRSAdvancedTableViews:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
-  HRSAdvancedTableViews: e77881f97ce5cde2556916ed095595ed8439b0a7
+  HRSAdvancedTableViews: f43f2de1517d17aa4fbf1638419296a17efffabd
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
 
 PODFILE CHECKSUM: bed599d9cacd1435baa1c624e4605659708ebabe
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.5.3

--- a/Pod/Classes/HRSSectionController/HRSTableViewSectionCoordinator.m
+++ b/Pod/Classes/HRSSectionController/HRSTableViewSectionCoordinator.m
@@ -715,7 +715,10 @@ static void *const CoordinatorTableViewLink = (void *)&CoordinatorTableViewLink;
 #pragma mark - scroll view delegate
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-	[[self.sectionController firstObject] scrollViewDidScroll:scrollView];
+    id<HRSTableViewSectionController> sectionController = [self.sectionController firstObject];
+    if ([sectionController respondsToSelector:_cmd]) {
+        [sectionController scrollViewDidScroll:scrollView];
+    }
 }
 
 - (void)scrollViewDidZoom:(UIScrollView *)scrollView {


### PR DESCRIPTION
Before forwarding a `- [UIScrollViewDelegate scrollViewDidScroll:]` method to a section controller, we should make sure it's implemented. We stumbled upon a case when one of the section controllers implemented this method, so the coordinator forwarded it other sections that didn't. Thus, causing a crash. 